### PR TITLE
Add comments retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,72 @@
+# Node.js
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# IDE/Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Logs
+logs
+*.log
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage/
+*.lcov
+
+# Dependency directories
+jspm_packages/
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Microbundle cache
+.rpt2_cache/
+.rts2_cache_cjs/
+.rts2_cache_es/
+.rts2_cache_umd/
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# dotenv environment variables file
+.env.test
+
+# Stores VSCode versions used for testing VSCode extensions
+.vscode-test

--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,6 @@
     // Load environment variables
     dotenv.config();
 
-    console.log('Starting Zendesk API MCP server...');
-
     // Start receiving messages on stdin and sending messages on stdout
     const transport = new StdioServerTransport();
     await server.connect(transport);

--- a/src/tools/tickets.js
+++ b/src/tools/tickets.js
@@ -159,5 +159,34 @@ import { z } from 'zod';
             };
           }
         }
+      },
+      {
+        name: "get_ticket_comments",
+        description: "Get all comments for a specific ticket",
+        schema: {
+          ticket_id: z.number().describe("Ticket ID"),
+          include_inline_images: z.boolean().optional().describe("Include inline images as attachments"),
+          include: z.string().optional().describe("Additional data to include (e.g., 'users')")
+        },
+        handler: async ({ ticket_id, include_inline_images, include }) => {
+          try {
+            const params = {};
+            if (include_inline_images !== undefined) params.include_inline_images = include_inline_images;
+            if (include !== undefined) params.include = include;
+
+            const result = await zendeskClient.getTicketComments(ticket_id, params);
+            return {
+              content: [{
+                type: "text",
+                text: JSON.stringify(result, null, 2)
+              }]
+            };
+          } catch (error) {
+            return {
+              content: [{ type: "text", text: `Error getting ticket comments: ${error.message}` }],
+              isError: true
+            };
+          }
+        }
       }
     ];

--- a/src/zendesk-client.js
+++ b/src/zendesk-client.js
@@ -70,6 +70,10 @@ import axios from 'axios';
         return this.request('DELETE', `/tickets/${id}.json`);
       }
 
+      async getTicketComments(ticketId, params) {
+        return this.request('GET', `/tickets/${ticketId}/comments.json`, null, params);
+      }
+
       // Users
       async listUsers(params) {
         return this.request('GET', '/users.json', null, params);


### PR DESCRIPTION
In order to create summaries of solutions related to a specific ticket being able to retrieve the comments for a ticket seemed necessary so I added that functionality in.

Also, I noticed that the `node_modules` folder isn't being excluded by a `.gitignore` file yet so one was added to help ensure certain local files / folders won't accidentally get committed.

The startup message was also removed from the `index.js` file since it results in the following error when the MCP server is being used with Claude Chat and possibly other tools too:
`MCP zendesk: Unexpected token 'S', "Starting Z"... is not valid JSON`